### PR TITLE
fix path for using.txt

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -22,7 +22,7 @@ if (argv.version) {
   process.stdout.write(package.version + '\n');
   process.exit();
 } else if (argv._.length === 0 || argv.help) {
-  process.stdout.write(fs.readFileSync('usage.txt'));
+  process.stdout.write(fs.readFileSync(path.join(__dirname, 'usage.txt')));
   process.exit();
 }
 


### PR DESCRIPTION
In not module dir, ghmd throws error:

```bash
user@host ~ # ghmd 
fs.js:93
      throw er;
      ^
Error: ENOENT: no such file or directory, open './usage.txt'
    at Error (native)
    at Object.fs.openSync (fs.js:549:18)
    at Object.fs.readFileSync (fs.js:399:15)
    at Object.<anonymous> (/usr/lib64/node_modules/github-markdown/cmd.js:25:27)
    at Module._compile (module.js:428:26)
    at Object.Module._extensions..js (module.js:446:10)
    at Module.load (module.js:353:32)
    at Function.Module._load (module.js:308:12)
    at Function.Module.runMain (module.js:469:10)
    at startup (node.js:124:18)
```