### PR TITLE
Fix highlightAuto (using wrong var)

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ class GitHubMarkdown {
           if (lang) {
             return hljs.highlight(lang, string).value;
           } else {
-            return hljs.highlightAuto(code).value;
+            return hljs.highlightAuto(string).value;
           }
         } catch (e) {
           console.error(e);


### PR DESCRIPTION
I was getting an error when I didn't specify a language on a code block. The variable `code` doesn't exist, so `highlightAuto` didn't work.