### PR TITLE
Enable html in order to support using html tags in your markdown.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ module.exports = (markdown, config = {}) => {
 
   const markdownIt = new MarkdownIt({
     langPrefix: 'hljs ',
+    html: true,
     highlight: (string, lang) => {
       try {
         if (lang) {


### PR DESCRIPTION
I noticed that this package encodes HTML tags while GitHub markdown supports HTML in their markdown files.